### PR TITLE
Use batch mode by default

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -32,7 +32,7 @@ id = "org.cloudfoundry.stacks.cflinuxfs3"
 [[metadata.configurations]]
 name        = "BP_MAVEN_BUILD_ARGUMENTS"
 description = "the arguments to pass to Maven"
-default     = "-Dmaven.test.skip=true package"
+default     = "--batch-mode -Dmaven.test.skip=true package"
 build       = true
 
 [[metadata.configurations]]


### PR DESCRIPTION
* maven is very verbose in CI if you don't use this option

## Summary
The batch mode option fits very well with CI tooling

## Use Cases
Take this build for example:
* Without batch mode, super verbose, for no added value:
https://github.com/anthonydahanne/java-applications-containerized/runs/1975032196

* With batch mode, much more concise
https://github.com/anthonydahanne/java-applications-containerized/runs/1975054421

## Checklist

* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
