### PR TITLE
Provides jvm-application-package instead of jvm-application

### DIFF
--- a/maven/build.go
+++ b/maven/build.go
@@ -35,7 +35,7 @@ import (
 type Build struct {
 	Logger             bard.Logger
 	ApplicationFactory ApplicationFactory
-	TTY bool
+	TTY                bool
 }
 
 type ApplicationFactory interface {
@@ -162,7 +162,7 @@ func contains(strings []string, stringsSearchedAfter []string) bool {
 			if v == stringSearchedAfter {
 				return true
 			}
-		}	
+		}
 	}
 	return false
 }

--- a/maven/build_test.go
+++ b/maven/build_test.go
@@ -56,7 +56,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 		Expect(err).NotTo(HaveOccurred())
 		mavenBuild = maven.Build{
 			ApplicationFactory: &FakeApplicationFactory{},
-			TTY: true,
+			TTY:                true,
 		}
 	})
 
@@ -69,15 +69,15 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 		Expect(ioutil.WriteFile(filepath.Join(ctx.Application.Path, "mvnw"), []byte{}, 0644)).To(Succeed())
 		ctx.StackID = "test-stack-id"
 		mavenBuild.TTY = false
-		
+
 		result, err := mavenBuild.Build(ctx)
 		Expect(err).NotTo(HaveOccurred())
-		
+
 		Expect(result.Layers[1].(libbs.Application).Arguments).To(Equal([]string{
 			"--batch-mode",
 			"test-argument",
 		}))
-		
+
 	})
 
 	context("BP_MAVEN_BUILD_ARGUMENTS includes --batch-mode", func() {

--- a/maven/detect.go
+++ b/maven/detect.go
@@ -24,6 +24,12 @@ import (
 	"github.com/buildpacks/libcnb"
 )
 
+const (
+	PlanEntryMaven                 = "maven"
+	PlanEntryJVMApplicationPackage = "jvm-application-package"
+	PlanEntryJDK                   = "jdk"
+)
+
 type Detect struct{}
 
 func (Detect) Detect(context libcnb.DetectContext) (libcnb.DetectResult, error) {
@@ -40,12 +46,12 @@ func (Detect) Detect(context libcnb.DetectContext) (libcnb.DetectResult, error) 
 		Plans: []libcnb.BuildPlan{
 			{
 				Provides: []libcnb.BuildPlanProvide{
-					{Name: "jvm-application"},
-					{Name: "maven"},
+					{Name: PlanEntryJVMApplicationPackage},
+					{Name: PlanEntryMaven},
 				},
 				Requires: []libcnb.BuildPlanRequire{
-					{Name: "jdk"},
-					{Name: "maven"},
+					{Name: PlanEntryJDK},
+					{Name: PlanEntryMaven},
 				},
 			},
 		},

--- a/maven/detect_test.go
+++ b/maven/detect_test.go
@@ -60,7 +60,7 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 			Plans: []libcnb.BuildPlan{
 				{
 					Provides: []libcnb.BuildPlanProvide{
-						{Name: "jvm-application"},
+						{Name: "jvm-application-package"},
 						{Name: "maven"},
 					},
 					Requires: []libcnb.BuildPlanRequire{


### PR DESCRIPTION
Changes name of provided plan entry to draw a distinction between a runnable JVM application (mostly process types) contributed by buildpacks like `paketo-buildpacks/executable-jar` and the packaged bytecode required as input to those buildpacks, provided by build system buildpacks like `paketo-buildpacks/maven`.