### PR TITLE
GH Issue 70 - mvnw file from Windows not executable

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,4 +9,5 @@ require (
 	github.com/paketo-buildpacks/libbs v1.8.2
 	github.com/paketo-buildpacks/libpak v1.51.1
 	github.com/sclevine/spec v1.4.0
+
 )

--- a/maven/build.go
+++ b/maven/build.go
@@ -17,10 +17,12 @@
 package maven
 
 import (
+	"bytes"
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"os"
 	"os/user"
 	"path/filepath"
@@ -82,6 +84,24 @@ func (b Build) Build(context libcnb.BuildContext) (libcnb.BuildResult, error) {
 		if err := os.Chmod(command, 0755); err != nil {
 			return libcnb.BuildResult{}, fmt.Errorf("unable to chmod %s\n%w", command, err)
 		}
+
+		file, err := ioutil.ReadFile(command)
+		if err != nil {
+			return libcnb.BuildResult{}, fmt.Errorf("unable to read mvnw file %s\n%w", command, err)
+		}
+
+		if bytes.ContainsAny(file, "\r\n") || bytes.ContainsAny(file, "\r") {
+
+			// the mvnw file can contain Windows CRLF line endings, e.g. from a 'git clone' on windows
+			// we call replaceLineEndings to replace these so that the unix container can execute the wrapper successfully
+			b := replaceLineEndings(file)
+
+			err = ioutil.WriteFile(command, []byte(b), 0755)
+			if err != nil {
+				return libcnb.BuildResult{}, fmt.Errorf("unable to process mvnw file format %s\n%w", command, err)
+			}
+		}
+
 	}
 
 	u, err := user.Current()
@@ -183,4 +203,13 @@ func contains(strings []string, stringsSearchedAfter []string) bool {
 		}
 	}
 	return false
+}
+
+// Added to ensure formatting of mvnw file is unix compatible
+func replaceLineEndings(d []byte) []byte {
+	// replace CRLF with LF
+	d = bytes.Replace(d, []byte{13, 10}, []byte{10}, -1)
+	// replace CF \r with LF
+	d = bytes.Replace(d, []byte{13}, []byte{10}, -1)
+	return d
 }

--- a/maven/build_test.go
+++ b/maven/build_test.go
@@ -17,6 +17,7 @@
 package maven_test
 
 import (
+	"bytes"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -264,6 +265,46 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 			expected = "91dff74ef3ab7f5ccb5808b32c30d2ab35b9f699d9a613c05a7f45eb83dd4c3a"
 			Expect(mdMap["settings-security-sha256"]).To(Equal(expected))
 		})
+	})
+
+	it("converts CRLF formatting in the mvnw file to LF (unix) if present", func() {
+		Expect(ioutil.WriteFile(filepath.Join(ctx.Application.Path, "mvnw"), []byte("test\r\n"), 0644)).To(Succeed())
+		ctx.StackID = "test-stack-id"
+
+		result, err := mavenBuild.Build(ctx)
+		Expect(err).NotTo(HaveOccurred())
+
+		_, err = os.Stat(filepath.Join(ctx.Application.Path, "mvnw"))
+		Expect(err).NotTo(HaveOccurred())
+
+		contents, err := ioutil.ReadFile(filepath.Join(ctx.Application.Path, "mvnw"))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(bytes.Compare(contents, []byte("test\n"))).To(Equal(0))
+
+		Expect(result.Layers).To(HaveLen(2))
+		Expect(result.Layers[0].Name()).To(Equal("cache"))
+		Expect(result.Layers[1].Name()).To(Equal("application"))
+		Expect(result.Layers[1].(libbs.Application).Command).To(Equal(filepath.Join(ctx.Application.Path, "mvnw")))
+	})
+
+	it("Does not perform format conversion in the mvnw file if not required", func() {
+		Expect(ioutil.WriteFile(filepath.Join(ctx.Application.Path, "mvnw"), []byte("test\n"), 0644)).To(Succeed())
+		ctx.StackID = "test-stack-id"
+
+		result, err := mavenBuild.Build(ctx)
+		Expect(err).NotTo(HaveOccurred())
+
+		_, err = os.Stat(filepath.Join(ctx.Application.Path, "mvnw"))
+		Expect(err).NotTo(HaveOccurred())
+
+		contents, err := ioutil.ReadFile(filepath.Join(ctx.Application.Path, "mvnw"))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(bytes.Compare(contents, []byte("test\n"))).To(Equal(0))
+
+		Expect(result.Layers).To(HaveLen(2))
+		Expect(result.Layers[0].Name()).To(Equal("cache"))
+		Expect(result.Layers[1].Name()).To(Equal("application"))
+		Expect(result.Layers[1].(libbs.Application).Command).To(Equal(filepath.Join(ctx.Application.Path, "mvnw")))
 	})
 }
 

--- a/maven/build_test.go
+++ b/maven/build_test.go
@@ -271,40 +271,26 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 		Expect(ioutil.WriteFile(filepath.Join(ctx.Application.Path, "mvnw"), []byte("test\r\n"), 0644)).To(Succeed())
 		ctx.StackID = "test-stack-id"
 
-		result, err := mavenBuild.Build(ctx)
-		Expect(err).NotTo(HaveOccurred())
-
-		_, err = os.Stat(filepath.Join(ctx.Application.Path, "mvnw"))
+		err := mavenBuild.CleanMvnWrapper(filepath.Join(ctx.Application.Path, "mvnw"))
 		Expect(err).NotTo(HaveOccurred())
 
 		contents, err := ioutil.ReadFile(filepath.Join(ctx.Application.Path, "mvnw"))
 		Expect(err).NotTo(HaveOccurred())
 		Expect(bytes.Compare(contents, []byte("test\n"))).To(Equal(0))
 
-		Expect(result.Layers).To(HaveLen(2))
-		Expect(result.Layers[0].Name()).To(Equal("cache"))
-		Expect(result.Layers[1].Name()).To(Equal("application"))
-		Expect(result.Layers[1].(libbs.Application).Command).To(Equal(filepath.Join(ctx.Application.Path, "mvnw")))
 	})
 
 	it("Does not perform format conversion in the mvnw file if not required", func() {
 		Expect(ioutil.WriteFile(filepath.Join(ctx.Application.Path, "mvnw"), []byte("test\n"), 0644)).To(Succeed())
 		ctx.StackID = "test-stack-id"
 
-		result, err := mavenBuild.Build(ctx)
-		Expect(err).NotTo(HaveOccurred())
-
-		_, err = os.Stat(filepath.Join(ctx.Application.Path, "mvnw"))
+		err := mavenBuild.CleanMvnWrapper(filepath.Join(ctx.Application.Path, "mvnw"))
 		Expect(err).NotTo(HaveOccurred())
 
 		contents, err := ioutil.ReadFile(filepath.Join(ctx.Application.Path, "mvnw"))
 		Expect(err).NotTo(HaveOccurred())
 		Expect(bytes.Compare(contents, []byte("test\n"))).To(Equal(0))
 
-		Expect(result.Layers).To(HaveLen(2))
-		Expect(result.Layers[0].Name()).To(Equal("cache"))
-		Expect(result.Layers[1].Name()).To(Equal("application"))
-		Expect(result.Layers[1].(libbs.Application).Command).To(Equal(filepath.Join(ctx.Application.Path, "mvnw")))
 	})
 }
 


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
Resolves paketo-buildpacks/maven#70

## Use Cases
An mvnw file with Windows line endings (CRLF) will cause the build in a linux container to fail due to the unrecognised formatting. The error appears as a file not found:

```fork/exec /workspace/source/app/mvnw: no such file or directory```

This PR adds a function which converts CRLF endings to LF so that the mvnw file can be executed successfully.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
