### PR TITLE
Allow maven buildpack to provide ear files

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -44,7 +44,7 @@ build       = true
 [[metadata.configurations]]
 name        = "BP_MAVEN_BUILT_ARTIFACT"
 description = "the built application artifact explicitly.  Supersedes $BP_MAVEN_BUILT_MODULE"
-default     = "target/*.[jw]ar"
+default     = "target/*.[ejw]ar"
 build       = true
 
 [[metadata.configurations]]


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
The maven-buildpack can easily build EAR files but the default `BP_MAVEN_BUILT_ARTIFACT` value does not allow them to be provided. This simply updates the value.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
