### PR TITLE
Add variable to specify custom pom.xml location

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ The Paketo Maven Buildpack is a Cloud Native Buildpack that builds Maven-based a
 ## Behavior
 This buildpack will participate all the following conditions are met
 
-* `<APPLICATION_ROOT>/pom.xml` exists
+* `<APPLICATION_ROOT>/pom.xml` exists or `BP_MAVEN_POM_FILE` is set to an existing POM file.
 
 The buildpack will do the following:
 
@@ -16,14 +16,15 @@ The buildpack will do the following:
   * Contributes Maven to a layer with all commands on `$PATH`
   * Runs `<MAVEN_ROOT>/bin/mvn -Dmaven.test.skip=true package` to build the application
 * Removes the source code in `<APPLICATION_ROOT>`
-* Expands `<APPLICATION_ROOT>/target/*.[jw]ar` to `<APPLICATION_ROOT>`
+* Expands `<APPLICATION_ROOT>/target/*.[ejw]ar` to `<APPLICATION_ROOT>`
 
 ## Configuration
 | Environment Variable | Description
 | -------------------- | -----------
 | `$BP_MAVEN_BUILD_ARGUMENTS` | Configure the arguments to pass to Maven.  Defaults to `-Dmaven.test.skip=true package`. `--batch-mode` will be prepended to the argument list in environments without a TTY.
 | `$BP_MAVEN_BUILT_MODULE` | Configure the module to find application artifact in.  Defaults to the root module (empty).
-| `$BP_MAVEN_BUILT_ARTIFACT` | Configure the built application artifact explicitly.  Supersedes `$BP_MAVEN_BUILT_MODULE`  Defaults to `target/*.[jw]ar`.
+| `$BP_MAVEN_BUILT_ARTIFACT` | Configure the built application artifact explicitly.  Supersedes `$BP_MAVEN_BUILT_MODULE`  Defaults to `target/*.[ejw]ar`.
+| `$BP_MAVEN_POM_FILE` | Specifies a custom location to the project's `pom.xml` file. Must be relative to the root of the project. Defaults to `pom.xml`.
 
 ## Bindings
 The buildpack optionally accepts the following bindings:

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The buildpack will do the following:
 | `$BP_MAVEN_BUILD_ARGUMENTS` | Configure the arguments to pass to Maven.  Defaults to `-Dmaven.test.skip=true package`. `--batch-mode` will be prepended to the argument list in environments without a TTY.
 | `$BP_MAVEN_BUILT_MODULE` | Configure the module to find application artifact in.  Defaults to the root module (empty).
 | `$BP_MAVEN_BUILT_ARTIFACT` | Configure the built application artifact explicitly.  Supersedes `$BP_MAVEN_BUILT_MODULE`  Defaults to `target/*.[ejw]ar`.
-| `$BP_MAVEN_POM_FILE` | Specifies a custom location to the project's `pom.xml` file. Must be relative to the root of the project. Defaults to `pom.xml`.
+| `$BP_MAVEN_POM_FILE` | Specifies a custom location to the project's `pom.xml` file. It should be a full path to the file under the `/workspace` directory or it should be relative to the root of the project (i.e. `/workspace'). Defaults to `pom.xml`.
 
 ## Bindings
 The buildpack optionally accepts the following bindings:

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -48,6 +48,13 @@ default     = "target/*.[ejw]ar"
 build       = true
 
 [[metadata.configurations]]
+name        = "BP_MAVEN_POM_FILE"
+description = "the location of the main pom.xml file, relative to the application root"
+default     = "pom.xml"
+detect      = true
+build       = true
+
+[[metadata.configurations]]
 name        = "BP_MAVEN_BUILT_MODULE"
 description = "the module to find application artifact in"
 build       = true

--- a/maven/build.go
+++ b/maven/build.go
@@ -105,6 +105,11 @@ func (b Build) Build(context libcnb.BuildContext) (libcnb.BuildResult, error) {
 		return libcnb.BuildResult{}, fmt.Errorf("unable to resolve build arguments\n%w", err)
 	}
 
+	pomFile, userSet := cr.Resolve("BP_MAVEN_POM_FILE")
+	if userSet {
+		args = append([]string{"--file", pomFile}, args...)
+	}
+
 	if !b.TTY && !contains(args, []string{"-B", "--batch-mode"}) {
 		// terminal is not tty, and the user did not set batch mode; let's set it
 		args = append([]string{"--batch-mode"}, args...)

--- a/maven/build_test.go
+++ b/maven/build_test.go
@@ -81,6 +81,25 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 
 	})
 
+	context("BP_MAVEN_POM_FILE is set", func() {
+		it.Before(func() {
+			Expect(os.Setenv("BP_MAVEN_POM_FILE", "foo/bar/pom.xml")).To(Succeed())
+		})
+
+		it.After(func() {
+			Expect(os.Unsetenv(("BP_MAVEN_POM_FILE"))).To(Succeed())
+		})
+
+		it("adds the --file argument if set", func() {
+			Expect(ioutil.WriteFile(filepath.Join(ctx.Application.Path, "mvnw"), []byte{}, 0644)).To(Succeed())
+
+			result, err := mavenBuild.Build(ctx)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(result.Layers[1].(libbs.Application).Arguments[0:2]).To(Equal([]string{"--file", "foo/bar/pom.xml"}))
+		})
+	})
+
 	context("BP_MAVEN_BUILD_ARGUMENTS includes --batch-mode", func() {
 		it.Before(func() {
 			Expect(os.Setenv("BP_MAVEN_BUILD_ARGUMENTS", "--batch-mode user-provided-argument")).To(Succeed())

--- a/maven/detect.go
+++ b/maven/detect.go
@@ -43,10 +43,6 @@ func (Detect) Detect(context libcnb.DetectContext) (libcnb.DetectResult, error) 
 	}
 
 	pomFile, _ := cr.Resolve("BP_MAVEN_POM_FILE")
-	if pomFile == "" {
-		pomFile = "pom.xml"
-	}
-
 	file := filepath.Join(context.Application.Path, pomFile)
 	_, err = os.Stat(file)
 	if os.IsNotExist(err) {

--- a/maven/detect_test.go
+++ b/maven/detect_test.go
@@ -49,11 +49,34 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 	})
 
 	it("fails without pom.xml", func() {
+		os.Setenv("BP_MAVEN_POM_FILE", "pom.xml")
 		Expect(detect.Detect(ctx)).To(Equal(libcnb.DetectResult{}))
 	})
 
 	it("passes with pom.xml", func() {
 		Expect(ioutil.WriteFile(filepath.Join(ctx.Application.Path, "pom.xml"), []byte{}, 0644))
+
+		Expect(detect.Detect(ctx)).To(Equal(libcnb.DetectResult{
+			Pass: true,
+			Plans: []libcnb.BuildPlan{
+				{
+					Provides: []libcnb.BuildPlanProvide{
+						{Name: "jvm-application-package"},
+						{Name: "maven"},
+					},
+					Requires: []libcnb.BuildPlanRequire{
+						{Name: "jdk"},
+						{Name: "maven"},
+					},
+				},
+			},
+		}))
+	})
+
+	it("passes with a custom pom.xml", func() {
+		Expect(ioutil.WriteFile(filepath.Join(ctx.Application.Path, "pom2.xml"), []byte{}, 0644))
+
+		os.Setenv("BP_MAVEN_POM_FILE", "pom2.xml")
 
 		Expect(detect.Detect(ctx)).To(Equal(libcnb.DetectResult{
 			Pass: true,


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
It is possible, though uncommon, to have a maven project with multiple modules and no root POM file; that is, you may have a structure that looks like this:
```
/
    parent/
        pom.xml
    childModule1/
        pom.xml
    childModule2/
        pom.xml
```

Where the `parent` project refers to `childModule{1,2}` using the `relativePath` directives. This PR will add the ability to specify the location to the desired `pom.xml` without having to root the project there.

## Use Cases
<!-- An explanation of the use cases your change enables -->
See above.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
