### PR TITLE
Newline at end of warnings

### DIFF
--- a/maven/build.go
+++ b/maven/build.go
@@ -100,11 +100,11 @@ func (b Build) Build(context libcnb.BuildContext) (libcnb.BuildResult, error) {
 			return libcnb.BuildResult{}, fmt.Errorf("unable to stat %s\n%w", command, err)
 		} else {
 			if err := os.Chmod(command, 0755); err != nil {
-				fmt.Printf("WARNING: unable to chmod %s:\n%s", command, err)
+				b.Logger.Bodyf("WARNING: unable to chmod %s:\n%s", command, err)
 			}
 
 			if err = b.CleanMvnWrapper(command); err != nil {
-				fmt.Printf("WARNING: unable to clean mvnw file: %s\n%s", command, err)
+				b.Logger.Bodyf("WARNING: unable to clean mvnw file: %s\n%s", command, err)
 			}
 		}
 	}


### PR DESCRIPTION
## Summary
Simple newline at end of warning logs

## Use Cases
Aligning debug console

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
