### PR TITLE
Implement RFC 0050: Rename Buildpack

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # `gcr.io/paketo-buildpacks/maven`
 
-The Paketo Maven Buildpack is a Cloud Native Buildpack that builds Maven-based applications from source.
+The Paketo Buildpack for Maven is a Cloud Native Buildpack that builds Maven-based applications from source.
 
 ## Behavior
 

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -19,7 +19,7 @@ api = "0.7"
   homepage = "https://github.com/paketo-buildpacks/maven"
   id = "paketo-buildpacks/maven"
   keywords = ["java", "maven", "build-system"]
-  name = "Paketo Maven Buildpack"
+  name = "Paketo Buildpack for Maven"
   sbom-formats = ["application/vnd.cyclonedx+json", "application/vnd.syft+json"]
   version = "{{.version}}"
 


### PR DESCRIPTION
Renames 'Paketo Maven Buildpack' to 'Paketo Buildpack for Maven'.

Implements RFC 0050, https://github.com/paketo-buildpacks/rfcs/issues/233, for this buildpack.

Signed-off-by: Daniel Mikusa <dmikusa@vmware.com>
