### PR TITLE
Maven dep

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,19 +6,24 @@ The Paketo Buildpack for Maven is a Cloud Native Buildpack that builds Maven-bas
 
 This buildpack will participate all the following conditions are met
 
+* Another buildpack requires `maven`, `jvm-application-package` or both
 * `<APPLICATION_ROOT>/pom.xml` exists or `BP_MAVEN_POM_FILE` is set to an existing POM file.
 
 The buildpack will do the following:
 
 * Requests that a JDK be installed
 * Links the `~/.m2` to a layer for caching
-* If `<APPLICATION_ROOT>/mvnw` exists
-  * Runs `<APPLICATION_ROOT>/mvnw -Dmaven.test.skip=true --no-transfer-progress package` to build the application
-* If `<APPLICATION_ROOT>/mvnw` does not exist
-  * Contributes Maven to a layer with all commands on `$PATH`
+* If `<APPLICATION_ROOT>/mvnw` does not exist and `mvn` is not on `$PATH`
+  * Contributes Maven or Maven Daemon to a layer with all commands on `$PATH`
   * Runs `<MAVEN_ROOT>/bin/mvn -Dmaven.test.skip=true --no-transfer-progress package` to build the application
   * Caches `$BP_MAVEN_BUILT_ARTIFACT` to a layer
-* Removes the source code in `<APPLICATION_ROOT>`
+* If `<APPLICATION_ROOT>/mvnw` exists
+  * Runs `<APPLICATION_ROOT>/mvnw -Dmaven.test.skip=true --no-transfer-progress package` to build the application
+  * Caches `$BP_MAVEN_BUILT_ARTIFACT` to a layer
+* If `mvn` is on `$PATH`
+  * Runs `mvn -Dmaven.test.skip=true --no-transfer-progress package` to build the application
+  * Caches `$BP_MAVEN_BUILT_ARTIFACT` to a layer
+* Removes the source code in `<APPLICATION_ROOT>`, following include/exclude rules
 * If `$BP_MAVEN_BUILT_ARTIFACT` matched a single file
   * Restores `$BP_MAVEN_BUILT_ARTIFACT` from the layer, expands the single file to `<APPLICATION_ROOT>`
 * If `$BP_MAVEN_BUILT_ARTIFACT` matched a directory or multiple files
@@ -26,14 +31,16 @@ The buildpack will do the following:
 
 ## Configuration
 
-| Environment Variable        | Description                                                                                                                                                                                                                        |
-| --------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `$BP_MAVEN_BUILD_ARGUMENTS` | Configure the arguments to pass to Maven.  Defaults to `-Dmaven.test.skip=true --no-transfer-progress package`. `--batch-mode` will be prepended to the argument list in environments without a TTY.                               |
-| `$BP_MAVEN_BUILT_MODULE`    | Configure the module to find application artifact in.  Defaults to the root module (empty).                                                                                                                                        |
-| `$BP_MAVEN_BUILT_ARTIFACT`  | Configure the built application artifact explicitly.  Supersedes `$BP_MAVEN_BUILT_MODULE`  Defaults to `target/*.[ejw]ar`. Can match a single file, multiple files or a directory. Can be one or more space separated patterns.    |
-| `$BP_MAVEN_POM_FILE`        | Specifies a custom location to the project's `pom.xml` file. It should be a full path to the file under the `/workspace` directory or it should be relative to the root of the project (i.e. `/workspace'). Defaults to `pom.xml`. |
-| `$BP_MAVEN_DAEMON_ENABLED`  | Triggers apache maven-mvnd to be installed and configured for use instead of Maven. The default value is `false`. Set to `true` to use the Maven Daemon.                                                                           |
-| `$BP_MAVEN_SETTINGS_PATH`  | Specifies a custom location to Maven's `settings.xml` file. If `$BP_MAVEN_SETTINGS_PATH` is set and a Maven binding is provided, the binding takes the higher precedence.  |
+| Environment Variable        | Description                                                                                                                                                                                                                                                          |
+| --------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `$BP_MAVEN_BUILD_ARGUMENTS` | Configure the arguments to pass to Maven.  Defaults to `-Dmaven.test.skip=true --no-transfer-progress package`. `--batch-mode` will be prepended to the argument list in environments without a TTY.                                                                 |
+| `$BP_MAVEN_BUILT_MODULE`    | Configure the module to find application artifact in.  Defaults to the root module (empty).                                                                                                                                                                          |
+| `$BP_MAVEN_BUILT_ARTIFACT`  | Configure the built application artifact explicitly.  Supersedes `$BP_MAVEN_BUILT_MODULE`  Defaults to `target/*.[ejw]ar`. Can match a single file, multiple files or a directory. Can be one or more space separated patterns.                                      |
+| `$BP_MAVEN_POM_FILE`        | Specifies a custom location to the project's `pom.xml` file. It should be a full path to the file under the `/workspace` directory or it should be relative to the root of the project (i.e. `/workspace'). Defaults to `pom.xml`.                                   |
+| `$BP_MAVEN_DAEMON_ENABLED`  | Triggers apache maven-mvnd to be installed and configured for use instead of Maven. The default value is `false`. Set to `true` to use the Maven Daemon.                                                                                                             |
+| `$BP_MAVEN_SETTINGS_PATH`   | Specifies a custom location to Maven's `settings.xml` file. If `$BP_MAVEN_SETTINGS_PATH` is set and a Maven binding is provided, the binding takes the higher precedence.                                                                                            |
+| `$BP_INCLUDE_FILES`         | Colon separated list of glob patterns to match source files. Any matched file will be retained in the final image. Defaults to `static/*:templates/*:public/*:html/*`.                                                                                               |
+| `$BP_EXCLUDE_FILES`         | Colon separated list of glob patterns to match source files. Any matched file will be specifically removed from the final image. If include patterns are also specified, then they are applied first and exclude patterns can be used to further reduce the fileset. |
 
 ## Bindings
 

--- a/maven/build.go
+++ b/maven/build.go
@@ -88,7 +88,7 @@ func (b Build) Build(context libcnb.BuildContext) (libcnb.BuildResult, error) {
 		result.BOM.Entries = append(result.BOM.Entries, *be)
 	}
 
-	// setup and run Maven
+	// setup Maven
 	u, err := user.Current()
 	if err != nil {
 		return libcnb.BuildResult{}, fmt.Errorf("unable to determine user home directory\n%w", err)
@@ -105,6 +105,7 @@ func (b Build) Build(context libcnb.BuildContext) (libcnb.BuildResult, error) {
 
 	bomScanner := sbom.NewSyftCLISBOMScanner(context.Layers, effect.NewExecutor(), b.Logger)
 
+	// build a layer contributor to run Maven
 	a, err := b.ApplicationFactory.NewApplication(
 		md,
 		args,

--- a/maven/build_test.go
+++ b/maven/build_test.go
@@ -84,7 +84,6 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 			"--batch-mode",
 			"test-argument",
 		}))
-
 	})
 
 	context("BP_MAVEN_POM_FILE is set", func() {

--- a/maven/detect_test.go
+++ b/maven/detect_test.go
@@ -48,9 +48,32 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 		Expect(os.RemoveAll(ctx.Application.Path)).To(Succeed())
 	})
 
-	it("fails without pom.xml", func() {
+	it("only provides with pom.xml", func() {
 		os.Setenv("BP_MAVEN_POM_FILE", "pom.xml")
-		Expect(detect.Detect(ctx)).To(Equal(libcnb.DetectResult{}))
+		Expect(detect.Detect(ctx)).To(Equal(libcnb.DetectResult{
+			Pass: true,
+			Plans: []libcnb.BuildPlan{
+				{
+					Provides: []libcnb.BuildPlanProvide{
+						{Name: "maven"},
+					},
+					Requires: []libcnb.BuildPlanRequire{
+						{Name: "jdk"},
+					},
+				},
+				{
+					Provides: []libcnb.BuildPlanProvide{
+						{Name: "jvm-application-package"},
+					},
+				},
+				{
+					Provides: []libcnb.BuildPlanProvide{
+						{Name: "jvm-application-package"},
+						{Name: "maven"},
+					},
+				},
+			},
+		}))
 	})
 
 	it("passes with pom.xml", func() {
@@ -59,6 +82,24 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 		Expect(detect.Detect(ctx)).To(Equal(libcnb.DetectResult{
 			Pass: true,
 			Plans: []libcnb.BuildPlan{
+				{
+					Provides: []libcnb.BuildPlanProvide{
+						{Name: "maven"},
+					},
+					Requires: []libcnb.BuildPlanRequire{
+						{Name: "jdk"},
+					},
+				},
+				{
+					Provides: []libcnb.BuildPlanProvide{
+						{Name: "jvm-application-package"},
+					},
+					Requires: []libcnb.BuildPlanRequire{
+						{Name: "syft"},
+						{Name: "jdk"},
+						{Name: "maven"},
+					},
+				},
 				{
 					Provides: []libcnb.BuildPlanProvide{
 						{Name: "jvm-application-package"},
@@ -82,6 +123,24 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 		Expect(detect.Detect(ctx)).To(Equal(libcnb.DetectResult{
 			Pass: true,
 			Plans: []libcnb.BuildPlan{
+				{
+					Provides: []libcnb.BuildPlanProvide{
+						{Name: "maven"},
+					},
+					Requires: []libcnb.BuildPlanRequire{
+						{Name: "jdk"},
+					},
+				},
+				{
+					Provides: []libcnb.BuildPlanProvide{
+						{Name: "jvm-application-package"},
+					},
+					Requires: []libcnb.BuildPlanRequire{
+						{Name: "syft"},
+						{Name: "jdk"},
+						{Name: "maven"},
+					},
+				},
 				{
 					Provides: []libcnb.BuildPlanProvide{
 						{Name: "jvm-application-package"},

--- a/maven/init_test.go
+++ b/maven/init_test.go
@@ -27,6 +27,7 @@ func TestUnit(t *testing.T) {
 	suite := spec.New("maven", spec.Report(report.Terminal{}))
 	suite("Build", testBuild)
 	suite("Detect", testDetect)
+	suite("MavenManagers", testMavenManager)
 	suite("Distribution", testDistribution)
 	suite("MvndDistribution", testMvndDistribution)
 	suite.Run(t)

--- a/maven/maven_manager.go
+++ b/maven/maven_manager.go
@@ -1,0 +1,189 @@
+package maven
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/buildpacks/libcnb"
+	"github.com/paketo-buildpacks/libpak"
+	"github.com/paketo-buildpacks/libpak/bard"
+)
+
+// MavenManager manages the lifecycle of a Maven distribution
+type MavenManager interface {
+	ShouldInstall() bool
+	Install() (string, libcnb.LayerContributor, *libcnb.BOMEntry, error)
+}
+
+// DaemonMavenManager provides the Maven daemon based Maven distribution
+type DaemonMavenManager struct {
+	configResolver libpak.ConfigurationResolver
+	depCache       libpak.DependencyCache
+	depResolver    libpak.DependencyResolver
+	layersPath     string
+	logger         bard.Logger
+}
+
+func NewDaemonMavenManager(configResolver libpak.ConfigurationResolver, depResolver libpak.DependencyResolver, depCache libpak.DependencyCache, layersPath string) DaemonMavenManager {
+	return DaemonMavenManager{
+		configResolver: configResolver,
+		depResolver:    depResolver,
+		depCache:       depCache,
+		layersPath:     layersPath,
+	}
+}
+
+// ShouldInstall the Maven Daemon
+func (d DaemonMavenManager) ShouldInstall() bool {
+	return d.configResolver.ResolveBool("BP_MAVEN_DAEMON_ENABLED")
+}
+
+// Install the Maven daemon tool
+func (d DaemonMavenManager) Install() (string, libcnb.LayerContributor, *libcnb.BOMEntry, error) {
+	dep, err := d.depResolver.Resolve("mvnd", "")
+	if err != nil {
+		return "", nil, nil, fmt.Errorf("unable to find dependency\n%w", err)
+	}
+
+	dist, be := NewMvndDistribution(dep, d.depCache)
+	dist.Logger = d.logger
+
+	command := filepath.Join(d.layersPath, dist.Name(), "bin", "mvnd")
+
+	return command, dist, &be, nil
+}
+
+// StandardMavenManager provides the standard JVM-based Maven distribution
+type StandardMavenManager struct {
+	appPath        string
+	configResolver libpak.ConfigurationResolver
+	depCache       libpak.DependencyCache
+	depResolver    libpak.DependencyResolver
+	layersPath     string
+	logger         bard.Logger
+}
+
+func NewStandardMavenManager(appPath string, configResolver libpak.ConfigurationResolver, depResolver libpak.DependencyResolver, depCache libpak.DependencyCache, layersPath string) StandardMavenManager {
+	return StandardMavenManager{
+		appPath:     appPath,
+		depResolver: depResolver,
+		depCache:    depCache,
+		layersPath:  layersPath,
+	}
+}
+
+// ShouldInstall the standard JVM-based Maven distribution
+func (s StandardMavenManager) ShouldInstall() bool {
+	command := filepath.Join(s.appPath, "mvnw")
+	_, err := os.Stat(command)
+	mvnwNotFound := os.IsNotExist(err)
+
+	_, err = exec.LookPath("mvn")
+	mvnNotOnPath := err != nil // or lookup failure
+
+	return mvnwNotFound && mvnNotOnPath
+}
+
+// Install the standard JVM-based Maven distribution
+func (s StandardMavenManager) Install() (string, libcnb.LayerContributor, *libcnb.BOMEntry, error) {
+	dep, err := s.depResolver.Resolve("maven", "")
+	if err != nil {
+		return "", nil, nil, fmt.Errorf("unable to find dependency\n%w", err)
+	}
+
+	dist, be := NewDistribution(dep, s.depCache)
+	dist.Logger = s.logger
+
+	command := filepath.Join(s.layersPath, dist.Name(), "bin", "mvn")
+
+	return command, dist, &be, nil
+}
+
+// WrapperMavenManager provides Maven through the Maven Wrapper
+type WrapperMavenManager struct {
+	appPath string
+	logger  bard.Logger
+}
+
+func NewWrapperMavenManager(appPath string, configResolver libpak.ConfigurationResolver, depResolver libpak.DependencyResolver, depCache libpak.DependencyCache) WrapperMavenManager {
+	return WrapperMavenManager{
+		appPath: appPath,
+	}
+}
+
+// ShouldInstall the Maven Wrapper
+func (s WrapperMavenManager) ShouldInstall() bool {
+	command := filepath.Join(s.appPath, "mvnw")
+	_, err := os.Stat(command)
+	return err == nil
+}
+
+// Install the Maven wrapper tool
+// Slightly misleading as this doesn't install anything, it just makes sure the wrapper can be run
+// The wrapper itself handles any installation, if it's necessary
+func (s WrapperMavenManager) Install() (string, libcnb.LayerContributor, *libcnb.BOMEntry, error) {
+	command := filepath.Join(s.appPath, "mvnw")
+
+	if err := os.Chmod(command, 0755); err != nil {
+		s.logger.Bodyf("WARNING: unable to chmod %s:\n%s", command, err)
+	}
+
+	if err := s.cleanMvnWrapper(command); err != nil {
+		s.logger.Bodyf("WARNING: unable to clean mvnw file: %s\n%s", command, err)
+	}
+
+	return command, nil, nil, nil
+}
+
+func (s WrapperMavenManager) cleanMvnWrapper(fileName string) error {
+	fileContents, err := os.ReadFile(fileName)
+	if err != nil {
+		return err
+	}
+
+	// the mvnw file can contain Windows CRLF line endings, e.g. from a 'git clone' on windows
+	// we replace these so that the unix container can execute the wrapper successfully
+
+	// replace CRLF with LF
+	fileContents = bytes.ReplaceAll(fileContents, []byte{13}, []byte{})
+
+	err = os.WriteFile(fileName, fileContents, 0755)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// NoopMavenManager doesn't provide Maven, but expects it to exist on the path
+type NoopMavenManager struct {
+	logger bard.Logger
+}
+
+func NewNoopMavenManager() NoopMavenManager {
+	return NoopMavenManager{}
+}
+
+// ShouldInstall determines if Maven is on the $PATH
+func (n NoopMavenManager) ShouldInstall() bool {
+	path, err := exec.LookPath("mvn")
+	return path != "" && err == nil
+}
+
+// Install nothing.
+// Slightly misleading as this doesn't install anything, it just makes sure mvn is on the $PATH
+func (n NoopMavenManager) Install() (string, libcnb.LayerContributor, *libcnb.BOMEntry, error) {
+	command, err := exec.LookPath("mvn")
+	if err != nil {
+		return "", nil, nil, fmt.Errorf("unable to lookup 'mvn'\n%w", err)
+	}
+
+	if command == "" {
+		return "", nil, nil, fmt.Errorf("unable to find 'mvn' on $PATH")
+	}
+
+	return command, nil, nil, nil
+}

--- a/maven/maven_manager_test.go
+++ b/maven/maven_manager_test.go
@@ -1,0 +1,256 @@
+package maven_test
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/buildpacks/libcnb"
+	. "github.com/onsi/gomega"
+	"github.com/paketo-buildpacks/libpak"
+	"github.com/paketo-buildpacks/maven/v6/maven"
+	"github.com/sclevine/spec"
+)
+
+func testMavenManager(t *testing.T, context spec.G, it spec.S) {
+	var (
+		Expect = NewWithT(t).Expect
+
+		ctx          libcnb.BuildContext
+		mavenManager maven.MavenManager
+		mvnwFilepath string
+	)
+
+	it.Before(func() {
+		var err error
+
+		ctx.Application.Path, err = os.MkdirTemp("", "build-application")
+		Expect(err).NotTo(HaveOccurred())
+
+		ctx.Layers.Path, err = os.MkdirTemp("", "build-layers")
+		Expect(err).NotTo(HaveOccurred())
+
+		mvnwFilepath = filepath.Join(ctx.Application.Path, "mvnw")
+	})
+
+	it.After(func() {
+		Expect(os.RemoveAll(ctx.Application.Path)).To(Succeed())
+		Expect(os.RemoveAll(ctx.Layers.Path)).To(Succeed())
+	})
+
+	context("StandardMavenManager", func() {
+		it.Before(func() {
+			dep := libpak.BuildpackDependency{
+				URI:     "https://localhost/stub-maven-distribution.tar.gz",
+				SHA256:  "31ba45356e22aff670af88170f43ff82328e6f323c3ce891ba422bd1031e3308",
+				Version: "1.1.1",
+				ID:      "maven",
+				Name:    "Maven",
+			}
+			dc := libpak.DependencyCache{CachePath: "testdata"}
+
+			mavenManager = maven.NewStandardMavenManager(
+				ctx.Application.Path,
+				libpak.ConfigurationResolver{},
+				libpak.DependencyResolver{
+					Dependencies: []libpak.BuildpackDependency{dep},
+					StackID:      "test-stack",
+				},
+				dc,
+				"/layers")
+		})
+
+		it("shouldn't install", func() {
+			Expect(os.WriteFile(mvnwFilepath, []byte{}, 0644)).ToNot(HaveOccurred())
+			Expect(mavenManager.ShouldInstall()).To(BeFalse())
+		})
+
+		it("should install", func() {
+			t.Setenv("PATH", "/doesnt-exist")
+			Expect(mavenManager.ShouldInstall()).To(BeTrue())
+		})
+
+		it("installs OK", func() {
+			cmd, layerContrib, _, err := mavenManager.Install()
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(cmd).To(Equal("/layers/maven/bin/mvn"))
+
+			Expect(layerContrib.Name()).To(Equal("maven"))
+			Expect(layerContrib.(maven.Distribution)).ToNot(BeNil())
+		})
+	})
+
+	context("DaemonMavenManager", func() {
+		var cfg libpak.BuildpackConfiguration
+
+		it.Before(func() {
+			dep := libpak.BuildpackDependency{
+				URI:     "https://localhost/stub-mvnd-distribution.zip",
+				SHA256:  "75458bf0354fde2c9762366e7d952489587e9d618630100b432a5486c4d22664",
+				Version: "1.1.1",
+				ID:      "mvnd",
+				Name:    "Maven",
+			}
+			dc := libpak.DependencyCache{CachePath: "testdata"}
+			cfg = libpak.BuildpackConfiguration{
+				Name:    "BP_MAVEN_DAEMON_ENABLED",
+				Default: "true",
+				Build:   true,
+			}
+
+			mavenManager = maven.NewDaemonMavenManager(
+				libpak.ConfigurationResolver{
+					Configurations: []libpak.BuildpackConfiguration{cfg},
+				},
+				libpak.DependencyResolver{
+					Dependencies: []libpak.BuildpackDependency{dep},
+					StackID:      "test-stack",
+				},
+				dc,
+				"/layers")
+		})
+
+		it("should install", func() {
+			Expect(mavenManager.ShouldInstall()).To(BeTrue())
+		})
+
+		it("shouldn't install", func() {
+			cfg.Default = "false"
+			Expect(mavenManager.ShouldInstall()).To(BeTrue())
+		})
+
+		it("installs OK", func() {
+			cmd, layerContrib, _, err := mavenManager.Install()
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(cmd).To(Equal("/layers/mvnd/bin/mvnd"))
+
+			Expect(layerContrib.Name()).To(Equal("mvnd"))
+			Expect(layerContrib.(maven.MvndDistribution)).ToNot(BeNil())
+		})
+	})
+
+	context("WrapperMavenManager", func() {
+		it.Before(func() {
+			dc := libpak.DependencyCache{CachePath: "testdata"}
+
+			mavenManager = maven.NewWrapperMavenManager(
+				ctx.Application.Path,
+				libpak.ConfigurationResolver{},
+				libpak.DependencyResolver{},
+				dc)
+		})
+
+		it("should install", func() {
+			Expect(os.WriteFile(mvnwFilepath, []byte{}, 0644)).ToNot(HaveOccurred())
+			Expect(mavenManager.ShouldInstall()).To(BeTrue())
+		})
+
+		it("shouldn't install", func() {
+			Expect(mavenManager.ShouldInstall()).To(BeFalse())
+		})
+
+		it("installs OK", func() {
+			Expect(os.WriteFile(mvnwFilepath, []byte{}, 0644)).ToNot(HaveOccurred())
+			cmd, layerContrib, _, err := mavenManager.Install()
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(cmd).To(Equal(mvnwFilepath))
+
+			Expect(layerContrib).To(BeNil())
+
+			// makes sure that mvnw is executable
+			fi, err := os.Stat(mvnwFilepath)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(fi.Mode()).To(BeEquivalentTo(0755))
+		})
+
+		it("proceeds without error if mvnw could not have been made executable", func() {
+			if _, err := os.Stat("/dev/null"); errors.Is(err, os.ErrNotExist) {
+				t.Skip("No /dev/null thus not a unix system. Skipping chmod test.")
+			}
+			Expect(os.Symlink("/dev/null", mvnwFilepath)).To(Succeed())
+			fi, err := os.Stat(mvnwFilepath)
+			Expect(err).NotTo(HaveOccurred())
+			originalMode := fi.Mode()
+			Expect(originalMode).ToNot(BeEquivalentTo(0755))
+			ctx.StackID = "test-stack-id"
+
+			_, _, _, err = mavenManager.Install()
+			Expect(err).NotTo(HaveOccurred())
+
+			fi, err = os.Stat(mvnwFilepath)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(fi.Mode()).To(BeEquivalentTo(originalMode))
+		})
+
+		it("converts CRLF formatting in the mvnw file to LF (unix) if present", func() {
+			Expect(os.WriteFile(mvnwFilepath, []byte("test\r\n"), 0644)).To(Succeed())
+			ctx.StackID = "test-stack-id"
+
+			_, _, _, err := mavenManager.Install()
+			Expect(err).NotTo(HaveOccurred())
+
+			contents, err := os.ReadFile(mvnwFilepath)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(bytes.Compare(contents, []byte("test\n"))).To(Equal(0))
+
+		})
+
+		it("does not perform format conversion in the mvnw file if not required", func() {
+			Expect(os.WriteFile(mvnwFilepath, []byte("test\n"), 0644)).To(Succeed())
+			ctx.StackID = "test-stack-id"
+
+			_, _, _, err := mavenManager.Install()
+			Expect(err).NotTo(HaveOccurred())
+
+			contents, err := os.ReadFile(mvnwFilepath)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(bytes.Compare(contents, []byte("test\n"))).To(Equal(0))
+		})
+	})
+
+	context("NoopMavenManager", func() {
+		var addToPath string
+		var mvnFilePath string
+
+		it.Before(func() {
+			var err error
+			addToPath, err = os.MkdirTemp("", "add-to-path")
+			Expect(err).NotTo(HaveOccurred())
+
+			t.Setenv("PATH", addToPath)
+
+			mvnFilePath = filepath.Join(addToPath, "mvn")
+
+			mavenManager = maven.NewNoopMavenManager()
+		})
+
+		it("should install", func() {
+			Expect(os.WriteFile(mvnFilePath, []byte{}, 0755)).ToNot(HaveOccurred())
+			Expect(mavenManager.ShouldInstall()).To(BeTrue())
+		})
+
+		it("shouldn't install", func() {
+			Expect(mavenManager.ShouldInstall()).To(BeFalse())
+		})
+
+		it("installs OK", func() {
+			Expect(os.WriteFile(mvnFilePath, []byte{}, 0755)).ToNot(HaveOccurred())
+			cmd, layerContrib, _, err := mavenManager.Install()
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(cmd).To(Equal(mvnFilePath))
+
+			Expect(layerContrib).To(BeNil())
+
+			// makes sure that mvn is executable
+			fi, err := os.Stat(mvnFilePath)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(fi.Mode()).To(BeEquivalentTo(0755))
+		})
+	})
+}


### PR DESCRIPTION
## Summary

### Changes to Detection:

1. By default, we now pass
2. By default, we provide three possible plans all of which only provide (one provides just maven, one provides just a built app, one provides maven and a built app)
3. If a `pom.xml` file exists, then we add a requires (jdk, syft, maven).

### Changes to Build:

Based on what is in the buildplan, the buildpack can now optionally install and optionally build.

If `maven` is in the buildplan, then the buildpack will attempt to install or validate that Maven is installed and generate a command to run Maven.

This can be done in four ways:

1. Install Maven Daemon
2. Install Maven
3. Validate Maven Wrapper
4. Validate Maven on $PATH

If `jvm-application-package` is in the buildplan, then the buildpack will attempt to perform a build with Maven. This uses the command from the previously installed or validated Maven.

## Use Cases

This enables four scenarios:

1. The buildpack installs & runs Maven (or Maven Daemon)
2. The buildpack runs Maven w/Maven Wrapper
3. The buildpack just installs Maven (or Maven Daemon)
4. The buildpack doesn't install Maven or use Maven Wrapper, but just runs Maven (Maven is provided through other means)

For 1.) & 2.) are the classic cases we've been supporting.
For 3.) & 4.) are the new cases that have been requested.

Resolves #159 
Resolves #184 