### PR TITLE
Adjust detect logic for WAR/JAR files

### DIFF
--- a/maven/detect.go
+++ b/maven/detect.go
@@ -37,6 +37,12 @@ const (
 type Detect struct{}
 
 func (Detect) Detect(context libcnb.DetectContext) (libcnb.DetectResult, error) {
+	// if MANIFEST.MF exists, we have a WAR/JAR so we don't build
+	_, err := os.Stat(filepath.Join(context.Application.Path, "META-INF", "MANIFEST.MF"))
+	if err == nil {
+		return libcnb.DetectResult{}, nil
+	}
+
 	l := bard.NewLogger(ioutil.Discard)
 	cr, err := libpak.NewConfigurationResolver(context.Buildpack, &l)
 	if err != nil {

--- a/maven/detect_test.go
+++ b/maven/detect_test.go
@@ -59,6 +59,15 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 		Expect(os.RemoveAll(ctx.Application.Path)).To(Succeed())
 	})
 
+	context("there is a META-INF/MANIFEST.MF", func() {
+		it("fails", func() {
+			Expect(os.MkdirAll(filepath.Join(ctx.Application.Path, "META-INF"), 0755)).Should(Succeed())
+			Expect(ioutil.WriteFile(filepath.Join(ctx.Application.Path, "META-INF", "MANIFEST.MF"), []byte{}, 0644))
+
+			Expect(detect.Detect(ctx)).To(Equal(libcnb.DetectResult{}))
+		})
+	})
+
 	context("there is no pom.xml", func() {
 		it("only provides looking at default location", func() {
 			Expect(detect.Detect(ctx)).To(Equal(libcnb.DetectResult{


### PR DESCRIPTION
## Summary

This PR adjusts the detection logic so that it'll work with WAR/JAR files as well as building from source. It looks to see if the `META-INF/MANIFEST.MF` file exists in the application root, which it will for a WAR/JAR, and if so detection fails fast (failing is OK because the buildpack is optional in the buildplan).

When building from source, this won't change any of the logic. There should not be a `META-INF/MANIFEST.MF` file when building from source.

## Use Cases

PR [#185](https://github.com/paketo-buildpacks/maven/pull/185) had an issue which caused problems when building from a WAR/JAR file.

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
