### PR TITLE
Maven Logic Improvements

### DIFF
--- a/maven/build.go
+++ b/maven/build.go
@@ -94,6 +94,11 @@ func (b Build) Build(context libcnb.BuildContext) (libcnb.BuildResult, error) {
 		if be != nil {
 			result.BOM.Entries = append(result.BOM.Entries, *be)
 		}
+	} else {
+		command, _, _, err = NewNoopMavenManager().Install()
+		if err != nil {
+			return libcnb.BuildResult{}, fmt.Errorf("unable pick Maven command\n%w", err)
+		}
 	}
 
 	// setup Maven

--- a/maven/build_test.go
+++ b/maven/build_test.go
@@ -327,6 +327,17 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 		})
 	})
 
+	context("maven is not in the buildplan nor on the path", func() {
+		it.Before(func() {
+			t.Setenv("PATH", "")
+		})
+
+		it("returns a meaningful error", func() {
+			_, err := mavenBuild.Build(ctx)
+			Expect(err).To(MatchError(ContainSubstring("unable to lookup 'mvn'")))
+		})
+	})
+
 	context("maven settings bindings exists", func() {
 		var result libcnb.BuildResult
 

--- a/maven/build_test.go
+++ b/maven/build_test.go
@@ -18,7 +18,6 @@ package maven_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -46,7 +45,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 	it.Before(func() {
 		var err error
 
-		ctx.Application.Path, err = ioutil.TempDir("", "build-application")
+		ctx.Application.Path, err = os.MkdirTemp("", "build-application")
 		Expect(err).NotTo(HaveOccurred())
 
 		ctx.Buildpack.Metadata = map[string]interface{}{
@@ -57,7 +56,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 
 		ctx.Plan.Entries = append(ctx.Plan.Entries, libcnb.BuildpackPlanEntry{Name: "jvm-application-package"})
 
-		ctx.Layers.Path, err = ioutil.TempDir("", "build-layers")
+		ctx.Layers.Path, err = os.MkdirTemp("", "build-layers")
 		Expect(err).NotTo(HaveOccurred())
 		mavenBuild = maven.Build{
 			ApplicationFactory: &FakeApplicationFactory{},
@@ -73,7 +72,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 	})
 
 	it("adds --batch-mode if terminal is not tty and the user did not specify it", func() {
-		Expect(ioutil.WriteFile(mvnwFilepath, []byte{}, 0644)).To(Succeed())
+		Expect(os.WriteFile(mvnwFilepath, []byte{}, 0644)).To(Succeed())
 		ctx.StackID = "test-stack-id"
 		mavenBuild.TTY = false
 
@@ -96,7 +95,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 		})
 
 		it("adds the --file argument if set", func() {
-			Expect(ioutil.WriteFile(mvnwFilepath, []byte{}, 0644)).To(Succeed())
+			Expect(os.WriteFile(mvnwFilepath, []byte{}, 0644)).To(Succeed())
 
 			result, err := mavenBuild.Build(ctx)
 			Expect(err).NotTo(HaveOccurred())
@@ -115,7 +114,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 		})
 
 		it("does not add --batch-mode a second time if terminal is not tty and the user already specified it", func() {
-			Expect(ioutil.WriteFile(mvnwFilepath, []byte{}, 0644)).To(Succeed())
+			Expect(os.WriteFile(mvnwFilepath, []byte{}, 0644)).To(Succeed())
 			ctx.StackID = "test-stack-id"
 			mavenBuild.TTY = false
 
@@ -139,7 +138,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 		})
 
 		it("sets the settings path", func() {
-			Expect(ioutil.WriteFile(mvnwFilepath, []byte{}, 0644)).To(Succeed())
+			Expect(os.WriteFile(mvnwFilepath, []byte{}, 0644)).To(Succeed())
 
 			result, err := mavenBuild.Build(ctx)
 			Expect(err).NotTo(HaveOccurred())
@@ -160,7 +159,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 		})
 
 		it("sets the settings path", func() {
-			Expect(ioutil.WriteFile(mvnwFilepath, []byte{}, 0644)).To(Succeed())
+			Expect(os.WriteFile(mvnwFilepath, []byte{}, 0644)).To(Succeed())
 
 			result, err := mavenBuild.Build(ctx)
 			Expect(err).NotTo(HaveOccurred())
@@ -175,7 +174,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 	it("does not contribute distribution if wrapper exists", func() {
 		ctx.Plan.Entries = append(ctx.Plan.Entries, libcnb.BuildpackPlanEntry{Name: "maven"})
 
-		Expect(ioutil.WriteFile(mvnwFilepath, []byte{}, 0644)).To(Succeed())
+		Expect(os.WriteFile(mvnwFilepath, []byte{}, 0644)).To(Succeed())
 		ctx.StackID = "test-stack-id"
 
 		result, err := mavenBuild.Build(ctx)
@@ -344,8 +343,9 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 		it.Before(func() {
 			var err error
 			ctx.StackID = "test-stack-id"
-			ctx.Platform.Path, err = ioutil.TempDir("", "maven-test-platform")
-			Expect(ioutil.WriteFile(mvnwFilepath, []byte{}, 0644)).To(Succeed())
+			ctx.Platform.Path, err = os.MkdirTemp("", "maven-test-platform")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(os.WriteFile(mvnwFilepath, []byte{}, 0644)).To(Succeed())
 			ctx.Platform.Bindings = libcnb.Bindings{
 				{
 					Name:   "some-maven",
@@ -357,7 +357,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 			mavenSettingsPath, ok := ctx.Platform.Bindings[0].SecretFilePath("settings.xml")
 			Expect(os.MkdirAll(filepath.Dir(mavenSettingsPath), 0777)).To(Succeed())
 			Expect(ok).To(BeTrue())
-			Expect(ioutil.WriteFile(
+			Expect(os.WriteFile(
 				mavenSettingsPath,
 				[]byte("maven-settings-content"),
 				0644,
@@ -398,7 +398,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 			})
 
 			it("sets the settings path to the bindings instead of the env var", func() {
-				Expect(ioutil.WriteFile(mvnwFilepath, []byte{}, 0644)).To(Succeed())
+				Expect(os.WriteFile(mvnwFilepath, []byte{}, 0644)).To(Succeed())
 
 				result, err := mavenBuild.Build(ctx)
 				Expect(err).NotTo(HaveOccurred())
@@ -417,8 +417,9 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 		it.Before(func() {
 			var err error
 			ctx.StackID = "test-stack-id"
-			ctx.Platform.Path, err = ioutil.TempDir("", "maven-test-platform")
-			Expect(ioutil.WriteFile(mvnwFilepath, []byte{}, 0644)).To(Succeed())
+			ctx.Platform.Path, err = os.MkdirTemp("", "maven-test-platform")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(os.WriteFile(mvnwFilepath, []byte{}, 0644)).To(Succeed())
 			ctx.Platform.Bindings = libcnb.Bindings{
 				{
 					Name: "some-maven",
@@ -433,7 +434,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 			mavenSettingsPath, ok := ctx.Platform.Bindings[0].SecretFilePath("settings.xml")
 			Expect(os.MkdirAll(filepath.Dir(mavenSettingsPath), 0777)).To(Succeed())
 			Expect(ok).To(BeTrue())
-			Expect(ioutil.WriteFile(
+			Expect(os.WriteFile(
 				mavenSettingsPath,
 				[]byte("maven-settings-content"),
 				0644,
@@ -442,7 +443,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 			mavenSettingsSecurityPath, ok := ctx.Platform.Bindings[0].SecretFilePath("settings-security.xml")
 			Expect(os.MkdirAll(filepath.Dir(mavenSettingsSecurityPath), 0777)).To(Succeed())
 			Expect(ok).To(BeTrue())
-			Expect(ioutil.WriteFile(
+			Expect(os.WriteFile(
 				mavenSettingsSecurityPath,
 				[]byte("maven-settings-security-content"),
 				0644,

--- a/maven/detect_test.go
+++ b/maven/detect_test.go
@@ -17,7 +17,6 @@
 package maven_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -51,7 +50,7 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 			},
 		}
 
-		ctx.Application.Path, err = ioutil.TempDir("", "maven")
+		ctx.Application.Path, err = os.MkdirTemp("", "maven")
 		Expect(err).NotTo(HaveOccurred())
 	})
 
@@ -62,7 +61,7 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 	context("there is a META-INF/MANIFEST.MF", func() {
 		it("fails", func() {
 			Expect(os.MkdirAll(filepath.Join(ctx.Application.Path, "META-INF"), 0755)).Should(Succeed())
-			Expect(ioutil.WriteFile(filepath.Join(ctx.Application.Path, "META-INF", "MANIFEST.MF"), []byte{}, 0644))
+			Expect(os.WriteFile(filepath.Join(ctx.Application.Path, "META-INF", "MANIFEST.MF"), []byte{}, 0644))
 
 			Expect(detect.Detect(ctx)).To(Equal(libcnb.DetectResult{}))
 		})
@@ -79,11 +78,6 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 						},
 						Requires: []libcnb.BuildPlanRequire{
 							{Name: "jdk"},
-						},
-					},
-					{
-						Provides: []libcnb.BuildPlanProvide{
-							{Name: "jvm-application-package"},
 						},
 					},
 					{
@@ -113,11 +107,6 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 					{
 						Provides: []libcnb.BuildPlanProvide{
 							{Name: "jvm-application-package"},
-						},
-					},
-					{
-						Provides: []libcnb.BuildPlanProvide{
-							{Name: "jvm-application-package"},
 							{Name: "maven"},
 						},
 					},
@@ -127,7 +116,7 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 	})
 
 	it("passes with pom.xml at the default location", func() {
-		Expect(ioutil.WriteFile(filepath.Join(ctx.Application.Path, "pom.xml"), []byte{}, 0644))
+		Expect(os.WriteFile(filepath.Join(ctx.Application.Path, "pom.xml"), []byte{}, 0644))
 
 		Expect(detect.Detect(ctx)).To(Equal(libcnb.DetectResult{
 			Pass: true,
@@ -143,6 +132,7 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 				{
 					Provides: []libcnb.BuildPlanProvide{
 						{Name: "jvm-application-package"},
+						{Name: "maven"},
 					},
 					Requires: []libcnb.BuildPlanRequire{
 						{Name: "syft"},
@@ -153,7 +143,6 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 				{
 					Provides: []libcnb.BuildPlanProvide{
 						{Name: "jvm-application-package"},
-						{Name: "maven"},
 					},
 					Requires: []libcnb.BuildPlanRequire{
 						{Name: "syft"},
@@ -166,7 +155,7 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 	})
 
 	it("passes with a pom.xml at a custom location", func() {
-		Expect(ioutil.WriteFile(filepath.Join(ctx.Application.Path, "pom2.xml"), []byte{}, 0644))
+		Expect(os.WriteFile(filepath.Join(ctx.Application.Path, "pom2.xml"), []byte{}, 0644))
 
 		t.Setenv("BP_MAVEN_POM_FILE", "pom2.xml")
 
@@ -184,6 +173,7 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 				{
 					Provides: []libcnb.BuildPlanProvide{
 						{Name: "jvm-application-package"},
+						{Name: "maven"},
 					},
 					Requires: []libcnb.BuildPlanRequire{
 						{Name: "syft"},
@@ -194,7 +184,6 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 				{
 					Provides: []libcnb.BuildPlanProvide{
 						{Name: "jvm-application-package"},
-						{Name: "maven"},
 					},
 					Requires: []libcnb.BuildPlanRequire{
 						{Name: "syft"},

--- a/maven/distribution_test.go
+++ b/maven/distribution_test.go
@@ -17,7 +17,6 @@
 package maven_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -40,7 +39,7 @@ func testDistribution(t *testing.T, context spec.G, it spec.S) {
 	it.Before(func() {
 		var err error
 
-		ctx.Layers.Path, err = ioutil.TempDir("", "distribution-layers")
+		ctx.Layers.Path, err = os.MkdirTemp("", "distribution-layers")
 		Expect(err).NotTo(HaveOccurred())
 	})
 

--- a/maven/mvnd_distribution_test.go
+++ b/maven/mvnd_distribution_test.go
@@ -17,7 +17,6 @@
 package maven_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -40,7 +39,7 @@ func testMvndDistribution(t *testing.T, context spec.G, it spec.S) {
 	it.Before(func() {
 		var err error
 
-		ctx.Layers.Path, err = ioutil.TempDir("", "distribution-layers")
+		ctx.Layers.Path, err = os.MkdirTemp("", "distribution-layers")
 		Expect(err).NotTo(HaveOccurred())
 	})
 


### PR DESCRIPTION
## Summary

This fixes a couple bugs:

1. A logic bug with selection of the maven command to run
2. A logic bug during detection, which allows non-Java apps to be incorrectly detected

Resolves #194 

## Use Cases

Fix bugs.

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
