### PR TITLE
Forgot double quote around regex

### DIFF
--- a/.github/pipeline-descriptor.yml
+++ b/.github/pipeline-descriptor.yml
@@ -27,7 +27,7 @@ dependencies:
     artifact_id:   apache-maven
     classifier:    bin
     packaging:     tar.gz
-    version_regex: ^3\\.[\\d]+\\.[\\d]+$
+    version_regex: "^3\\.[\\d]+\\.[\\d]+$"
 - name:            Maven 4
   id:              maven
   uses:            docker://ghcr.io/paketo-buildpacks/actions/maven-dependency:main
@@ -38,7 +38,7 @@ dependencies:
     artifact_id:   apache-maven
     classifier:    bin
     packaging:     tar.gz
-    version_regex: ^4\\.[\\d]+\\.[\\d]+-.*$
+    version_regex: "^4\\.[\\d]+\\.[\\d]+-.*$"
 - id:   mvnd
   uses: docker://ghcr.io/paketo-buildpacks/actions/github-release-dependency:main
   with:

--- a/.github/workflows/pb-update-maven-3.yml
+++ b/.github/workflows/pb-update-maven-3.yml
@@ -49,7 +49,7 @@ jobs:
                 group_id: org.apache.maven
                 packaging: tar.gz
                 uri: https://repo1.maven.org/maven2
-                version_regex: ^3\\.[\\d]+\\.[\\d]+$
+                version_regex: ^3\.[\d]+\.[\d]+$
             - name: Update Buildpack Dependency
               id: buildpack
               run: |-

--- a/.github/workflows/pb-update-maven-4.yml
+++ b/.github/workflows/pb-update-maven-4.yml
@@ -49,7 +49,7 @@ jobs:
                 group_id: org.apache.maven
                 packaging: tar.gz
                 uri: https://repo1.maven.org/maven2
-                version_regex: ^4\\.[\\d]+\\.[\\d]+-.*$
+                version_regex: ^4\.[\d]+\.[\d]+-.*$
             - name: Update Buildpack Dependency
               id: buildpack
               run: |-


### PR DESCRIPTION
I skipped the double quotes around the regex. This meant the escaped backslashes were not unescaped, which breaks the regex.

Regular expression patterns in yaml files should either be quoted, in which case you need to escape backslashes, or not quoted and then you do not need to escape the backslashes.

Signed-off-by: Daniel Mikusa <dan@mikusa.com>
