### PR TITLE
Try to parse java.version from pom.xml

### DIFF
--- a/maven/detect.go
+++ b/maven/detect.go
@@ -83,11 +83,18 @@ func (Detect) Detect(context libcnb.DetectContext) (libcnb.DetectResult, error) 
 			},
 		})
 
+		jdkRequire := libcnb.BuildPlanRequire{Name: PlanEntryJDK}
+		version, err := ParseJDKVersionFromPOM(file)
+		if err == nil && version != "" {
+			jdkRequire.Metadata = map[string]interface{}{"version": version}
+			result.Plans[0].Requires[0].Metadata = map[string]interface{}{"version": version}
+		}
+
 		// add requires for install & build
 		for i := 1; i < len(result.Plans); i++ {
 			result.Plans[i].Requires = []libcnb.BuildPlanRequire{
 				{Name: PlanEntrySyft},
-				{Name: PlanEntryJDK},
+				jdkRequire,
 				{Name: PlanEntryMaven},
 			}
 		}

--- a/maven/detect_test.go
+++ b/maven/detect_test.go
@@ -154,6 +154,47 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 		}))
 	})
 
+	it("requires the jdk version from pom.xml (spring boot)", func() {
+		data, err := os.ReadFile(filepath.Join("testdata", "spring-boot-pom.xml"))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(os.WriteFile(filepath.Join(ctx.Application.Path, "pom.xml"), data, 0644))
+
+		Expect(detect.Detect(ctx)).To(Equal(libcnb.DetectResult{
+			Pass: true,
+			Plans: []libcnb.BuildPlan{
+				{
+					Provides: []libcnb.BuildPlanProvide{
+						{Name: "maven"},
+					},
+					Requires: []libcnb.BuildPlanRequire{
+						{Name: "jdk", Metadata: map[string]interface{}{"version": "17"}},
+					},
+				},
+				{
+					Provides: []libcnb.BuildPlanProvide{
+						{Name: "jvm-application-package"},
+						{Name: "maven"},
+					},
+					Requires: []libcnb.BuildPlanRequire{
+						{Name: "syft"},
+						{Name: "jdk", Metadata: map[string]interface{}{"version": "17"}},
+						{Name: "maven"},
+					},
+				},
+				{
+					Provides: []libcnb.BuildPlanProvide{
+						{Name: "jvm-application-package"},
+					},
+					Requires: []libcnb.BuildPlanRequire{
+						{Name: "syft"},
+						{Name: "jdk", Metadata: map[string]interface{}{"version": "17"}},
+						{Name: "maven"},
+					},
+				},
+			},
+		}))
+	})
+
 	it("passes with a pom.xml at a custom location", func() {
 		Expect(os.WriteFile(filepath.Join(ctx.Application.Path, "pom2.xml"), []byte{}, 0644))
 

--- a/maven/init_test.go
+++ b/maven/init_test.go
@@ -27,6 +27,7 @@ func TestUnit(t *testing.T) {
 	suite := spec.New("maven", spec.Report(report.Terminal{}))
 	suite("Build", testBuild)
 	suite("Detect", testDetect)
+	suite("ParsePOM", testParsePOM)
 	suite("MavenManagers", testMavenManager)
 	suite("Distribution", testDistribution)
 	suite("MvndDistribution", testMvndDistribution)

--- a/maven/pom.go
+++ b/maven/pom.go
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2018-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package maven
+
+import (
+	"encoding/xml"
+	"io/ioutil"
+	"os"
+)
+
+type pomProject struct {
+	XMLName    xml.Name      `xml:"project"`
+	Properties pomProperties `xml:"properties"`
+}
+
+type pomProperties struct {
+	JavaVersion string `xml:"java.version"`
+}
+
+func ParseJDKVersionFromPOM(filename string) (string, error) {
+	pomFile, err := os.Open(filename)
+	if err != nil {
+		return "", err
+	}
+	defer pomFile.Close()
+	byteValue, err := ioutil.ReadAll(pomFile)
+
+	project := pomProject{}
+	xml.Unmarshal(byteValue, &project)
+	if err != nil {
+		return "", err
+	}
+
+	if project.Properties.JavaVersion != "" {
+		return project.Properties.JavaVersion, nil
+	}
+
+	return "", nil
+}

--- a/maven/pom_test.go
+++ b/maven/pom_test.go
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2018-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package maven_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	"github.com/paketo-buildpacks/maven/v6/maven"
+	"github.com/sclevine/spec"
+)
+
+func testParsePOM(t *testing.T, context spec.G, it spec.S) {
+	var (
+		path   string
+		Expect = NewWithT(t).Expect
+		err    error
+	)
+
+	it.Before(func() {
+		path, err = os.MkdirTemp("", "pom")
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	it.After(func() {
+		Expect(os.RemoveAll(path)).To(Succeed())
+	})
+
+	context("parsing JDK version from POM", func() {
+		it("fails if file does not exist", func() {
+			_, err = maven.ParseJDKVersionFromPOM("doesNotExist")
+
+			Expect(os.IsNotExist(err)).To(BeTrue())
+		})
+
+		it("returns empty string if no version found", func() {
+			filename := filepath.Join(path, "pom.xml")
+			os.WriteFile(filename, []byte(""), os.ModePerm)
+			version, err := maven.ParseJDKVersionFromPOM(filename)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(version).To(Equal(""))
+		})
+
+		it("returns java.version", func() {
+			content :=
+				`<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0">
+	<properties>
+		<java.version>17</java.version>
+	</properties>
+</project>
+`
+			filename := filepath.Join(path, "pom.xml")
+			os.WriteFile(filename, []byte(content), os.ModePerm)
+			version, err := maven.ParseJDKVersionFromPOM(filename)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(version).To(Equal("17"))
+		})
+
+	})
+}

--- a/maven/testdata/spring-boot-pom.xml
+++ b/maven/testdata/spring-boot-pom.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>3.0.0-M4</version>
+        <relativePath/> <!-- lookup parent from repository -->
+    </parent>
+
+    <groupId>com.in28minutes.springboot</groupId>
+    <artifactId>student-services-security</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <name>student-services</name>
+    <description>Demo project for Spring Boot</description>
+
+    <properties>
+        <java.version>17</java.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-security</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.tomcat.embed</groupId>
+            <artifactId>tomcat-embed-jasper</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-devtools</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
+    <repositories>
+        <repository>
+            <id>spring-milestones</id>
+            <name>Spring Milestones</name>
+            <url>https://repo.spring.io/milestone</url>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
+
+    <pluginRepositories>
+        <pluginRepository>
+            <id>spring-milestones</id>
+            <name>Spring Milestones</name>
+            <url>https://repo.spring.io/milestone</url>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </pluginRepository>
+    </pluginRepositories>
+
+</project>


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->
see #217 

## Summary
<!-- A short explanation of the proposed change -->
If a `pom.xml` is found, it is parsed and checked for the `java.version` property (spring boot). If the property is found, this information is used to not only require a JDK, but a JDK of the correct version.

## Use Cases
<!-- An explanation of the use cases your change enables -->
If a spring boot application is requiring a specific java version (e.g. 17) which is different from the default one being installed, the user is not forced to provide `BP_JDK_VERSION`, but the version is auto detected.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
