### PR TITLE
Do not use effect.NewExecutor use CommandExecutor instead

### DIFF
--- a/maven/build.go
+++ b/maven/build.go
@@ -119,7 +119,7 @@ func (b Build) Build(context libcnb.BuildContext) (libcnb.BuildResult, error) {
 	if _, found, err := pr.Resolve(PlanEntryJVMApplicationPackage); err != nil {
 		return libcnb.BuildResult{}, fmt.Errorf("unable to resolve JVM Application Package plan entry\n%w", err)
 	} else if found {
-		bomScanner := sbom.NewSyftCLISBOMScanner(context.Layers, effect.NewExecutor(), b.Logger)
+		bomScanner := sbom.NewSyftCLISBOMScanner(context.Layers, effect.CommandExecutor{}, b.Logger)
 
 		// build a layer contributor to run Maven
 		a, err := b.ApplicationFactory.NewApplication(

--- a/maven/maven_manager_test.go
+++ b/maven/maven_manager_test.go
@@ -20,9 +20,9 @@ func testMavenManager(t *testing.T, context spec.G, it spec.S) {
 	var (
 		Expect = NewWithT(t).Expect
 
-		ctx          libcnb.BuildContext
-		mavenManager maven.MavenManager
-		mvnwFilepath string
+		ctx           libcnb.BuildContext
+		mavenManager  maven.MavenManager
+		mvnwFilepath  string
 		mvnwPropsPath string
 	)
 
@@ -36,10 +36,12 @@ func testMavenManager(t *testing.T, context spec.G, it spec.S) {
 		Expect(err).NotTo(HaveOccurred())
 
 		mvnwFilepath = filepath.Join(ctx.Application.Path, "mvnw")
-		mvnwPropsPath = filepath.Join(ctx.Application.Path, ".mvn/wrapper/") 
-		
+		mvnwPropsPath = filepath.Join(ctx.Application.Path, ".mvn/wrapper/")
+
 		err = os.MkdirAll(mvnwPropsPath, 0755)
 		Expect(err).NotTo(HaveOccurred())
+
+		t.Setenv("BP_ARCH", "amd64")
 	})
 
 	it.After(func() {
@@ -273,13 +275,13 @@ func testMavenManager(t *testing.T, context spec.G, it spec.S) {
 		it("converts CRLF formatting in the maven-wrapper.properties file to LF (unix) if present", func() {
 			propsFile := filepath.Join(mvnwPropsPath, "maven-wrapper.properties")
 			Expect(os.WriteFile(propsFile, []byte("test\r\n"), 0755)).To(Succeed())
-	
-			_, _, _, err := mavenManager.Install()
-                        Expect(err).NotTo(HaveOccurred())
 
-                        contents, err := os.ReadFile(propsFile)
-                        Expect(err).NotTo(HaveOccurred())
-                        Expect(bytes.Compare(contents, []byte("test\n"))).To(Equal(0))
+			_, _, _, err := mavenManager.Install()
+			Expect(err).NotTo(HaveOccurred())
+
+			contents, err := os.ReadFile(propsFile)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(bytes.Compare(contents, []byte("test\n"))).To(Equal(0))
 		})
 
 	})


### PR DESCRIPTION
## Summary
When running `syft`, do not use effect.NewExecutor which runs the command with a tty. This seems to cause an issue with syft (or possibly with our tty library pty), and in either case you end up with stray formatting characters even though we tell syft to be quiet. Using CommandExecutor is basically the same, but it doesn't run with a tty.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
