### PR TITLE
Fix MVND metadata problems

### DIFF
--- a/.github/pipeline-descriptor.yml
+++ b/.github/pipeline-descriptor.yml
@@ -39,16 +39,8 @@ dependencies:
     classifier:    bin
     packaging:     tar.gz
     version_regex: "^4\\.[\\d]+\\.[\\d]+-.*$"
-- name: Maven Daemon 0
-  id:   mvnd
-  uses: docker://ghcr.io/paketo-buildpacks/actions/github-release-dependency:main
-  version_pattern: "^0\\.[\\d]+\\.[\\d]$"
-  with:
-    owner: apache
-    repository: maven-mvnd
-    glob: mvnd-.+-linux-amd64.zip
-    tag_filter: "(^0\\.[\\d]+\\.[\\d])$"
-    token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
+
+# AMD64
 - name: Maven Daemon 1
   id:   mvnd
   uses: docker://ghcr.io/paketo-buildpacks/actions/github-release-dependency:main
@@ -59,3 +51,17 @@ dependencies:
     glob: mvnd-.+-linux-amd64.zip
     tag_filter: "^(1\\.[\\d]+\\.[\\d](?:-.*)?)$"
     token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
+
+# ARM64
+- name: Maven Daemon 1 ARM64
+  id:   mvnd
+  uses: docker://ghcr.io/paketo-buildpacks/actions/github-release-dependency:main
+  version_pattern: "^1\\.[\\d]+\\.[\\d](?:-.*)?$"
+  with:
+    owner: apache
+    repository: maven-mvnd
+    glob: mvnd-.+-linux-aarch64.zip
+    tag_filter: "^(1\\.[\\d]+\\.[\\d](?:-.*)?)$"
+    token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
+    arch: arm64
+

--- a/.github/workflows/pb-update-maven-daemon-1-arm-64.yml
+++ b/.github/workflows/pb-update-maven-daemon-1-arm-64.yml
@@ -1,4 +1,4 @@
-name: Update Maven Daemon 0
+name: Update Maven Daemon 1 ARM64
 "on":
     schedule:
         - cron: 0 5 * * 1-5
@@ -27,10 +27,11 @@ jobs:
             - id: dependency
               uses: docker://ghcr.io/paketo-buildpacks/actions/github-release-dependency:main
               with:
-                glob: mvnd-.+-linux-amd64.zip
+                arch: arm64
+                glob: mvnd-.+-linux-aarch64.zip
                 owner: apache
                 repository: maven-mvnd
-                tag_filter: (^0\.[\d]+\.[\d])$
+                tag_filter: ^(1\.[\d]+\.[\d](?:-.*)?)$
                 token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
             - name: Update Buildpack Dependency
               id: buildpack
@@ -78,7 +79,7 @@ jobs:
                 echo "new-version=${VERSION}" >> "$GITHUB_OUTPUT"
                 echo "version-label=${LABEL}" >> "$GITHUB_OUTPUT"
               env:
-                ARCH: ""
+                ARCH: arm64
                 CPE: ${{ steps.dependency.outputs.cpe }}
                 CPE_PATTERN: ""
                 ID: mvnd
@@ -89,18 +90,18 @@ jobs:
                 SOURCE_URI: ${{ steps.dependency.outputs.source }}
                 URI: ${{ steps.dependency.outputs.uri }}
                 VERSION: ${{ steps.dependency.outputs.version }}
-                VERSION_PATTERN: ^0\.[\d]+\.[\d]$
+                VERSION_PATTERN: ^1\.[\d]+\.[\d](?:-.*)?$
             - uses: peter-evans/create-pull-request@v8
               with:
                 author: ${{ secrets.JAVA_GITHUB_USERNAME }} <${{ secrets.JAVA_GITHUB_USERNAME }}@users.noreply.github.com>
-                body: Bumps `Maven Daemon 0` from `${{ steps.buildpack.outputs.old-version }}` to `${{ steps.buildpack.outputs.new-version }}`.
-                branch: update/buildpack/maven-daemon-0
+                body: Bumps `Maven Daemon 1 ARM64` from `${{ steps.buildpack.outputs.old-version }}` to `${{ steps.buildpack.outputs.new-version }}`.
+                branch: update/buildpack/maven-daemon-1-arm-64
                 commit-message: |-
-                    Bump Maven Daemon 0 from ${{ steps.buildpack.outputs.old-version }} to ${{ steps.buildpack.outputs.new-version }}
+                    Bump Maven Daemon 1 ARM64 from ${{ steps.buildpack.outputs.old-version }} to ${{ steps.buildpack.outputs.new-version }}
 
-                    Bumps Maven Daemon 0 from ${{ steps.buildpack.outputs.old-version }} to ${{ steps.buildpack.outputs.new-version }}.
+                    Bumps Maven Daemon 1 ARM64 from ${{ steps.buildpack.outputs.old-version }} to ${{ steps.buildpack.outputs.new-version }}.
                 delete-branch: true
                 labels: ${{ steps.buildpack.outputs.version-label }}, type:dependency-upgrade
                 signoff: true
-                title: Bump Maven Daemon 0 from ${{ steps.buildpack.outputs.old-version }} to ${{ steps.buildpack.outputs.new-version }}
+                title: Bump Maven Daemon 1 ARM64 from ${{ steps.buildpack.outputs.old-version }} to ${{ steps.buildpack.outputs.new-version }}
                 token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -141,31 +141,31 @@ api = "0.7"
       uri = "https://www.apache.org/licenses/"
 
   [[metadata.dependencies]]
-    cpes = ["cpe:2.3:a:apache:mvnd:0.9.0:*:*:*:*:*:*:*"]
+    cpes = ["cpe:2.3:a:apache:mvnd:1.0.6:*:*:*:*:*:*:*"]
     id = "mvnd"
     name = "Apache Maven Daemon"
-    purl = "pkg:generic/apache-mvnd@0.9.0"
-    sha256 = "5d33a9a5964905381df1e132a1a4c0cc6e4b7c72f75daa2d799181b68091fe9f"
-    source = "https://github.com/apache/maven-mvnd/archive/refs/tags/0.9.0.tar.gz"
-    source-sha256 = "20435e39db7586ab740b3c90b8d209fc6483c67faef77452cea1f0b2b0b85d38"
+    purl = "pkg:generic/apache-mvnd@1.0.6"
+    sha256 = "1a1c2ad0de53669c6d2bf64e2b6bcc7cb96f592c543230f00b4209002b19083c"
+    source = "https://github.com/apache/maven-mvnd/archive/refs/tags/1.0.6.tar.gz"
+    source-sha256 = "c430af196511a680262dda91750071bbc2d01278fc603a574989fc337b94a894"
     stacks = ["io.buildpacks.stacks.bionic", "io.paketo.stacks.tiny", "*"]
-    uri = "https://github.com/apache/maven-mvnd/releases/download/0.9.0/maven-mvnd-0.9.0-linux-amd64.zip"
-    version = "0.9.0"
+    uri = "https://github.com/apache/maven-mvnd/releases/download/1.0.6/maven-mvnd-1.0.6-linux-amd64.zip"
+    version = "1.0.6"
 
     [[metadata.dependencies.licenses]]
       type = "Apache-2.0"
       uri = "https://www.apache.org/licenses/"
 
   [[metadata.dependencies]]
-    cpes = ["cpe:2.3:a:apache:mvnd:1.0.2:*:*:*:*:*:*:*"]
+    cpes = ["cpe:2.3:a:apache:mvnd:1.0.6:*:*:*:*:*:*:*"]
     id = "mvnd"
     name = "Apache Maven Daemon"
-    purl = "pkg:generic/apache-mvnd@1.0.4"
-    sha256 = "1a1c2ad0de53669c6d2bf64e2b6bcc7cb96f592c543230f00b4209002b19083c"
+    purl = "pkg:generic/apache-mvnd@1.0.6?arch=arm64"
+    sha256 = "f23c319112f9f1ac50082eed2768f24551420fd2f31773045679de1e831588b7"
     source = "https://github.com/apache/maven-mvnd/archive/refs/tags/1.0.6.tar.gz"
     source-sha256 = "c430af196511a680262dda91750071bbc2d01278fc603a574989fc337b94a894"
     stacks = ["io.buildpacks.stacks.bionic", "io.paketo.stacks.tiny", "*"]
-    uri = "https://github.com/apache/maven-mvnd/releases/download/1.0.6/maven-mvnd-1.0.6-linux-amd64.zip"
+    uri = "https://github.com/apache/maven-mvnd/releases/download/1.0.6/maven-mvnd-1.0.6-linux-aarch64.zip"
     version = "1.0.6"
 
     [[metadata.dependencies.licenses]]


### PR DESCRIPTION
- Was missing ARM64 dependencies for mvnd
- MVND metadata was incorrect for purl/cpes
- Missing update job for mvnd arm64
- Drops mvnd v0, which hasn't been updated since 2023. v1 has been out since then and v2 is in RC stages. Considering v0 as EOL.